### PR TITLE
Support all profile types for AEA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ Temporary Items
 # End of https://www.toptal.com/developers/gitignore/api/macos,visualstudiocode
 
 build/
+ignored/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,59 @@
-# Ignore the build directory
-build/
+# Created by https://www.toptal.com/developers/gitignore/api/macos,visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=macos,visualstudiocode
 
-# Ignore .DS_Store files (macOS specific)
+### macOS ###
+# General
 .DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud
+
+### VisualStudioCode ###
+.vscode/
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# End of https://www.toptal.com/developers/gitignore/api/macos,visualstudiocode
+
+build/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "libNeoAppleArchive/compression/lzfse"]
 	path = libNeoAppleArchive/compression/lzfse
 	url = https://github.com/lzfse/lzfse.git
+[submodule "libNeoAppleArchive/compression/libzbitmap"]
+	path = libNeoAppleArchive/compression/libzbitmap
+	url = https://github.com/eafer/libzbitmap.git

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 buildDir = build
 CC = clang
-CFLAGS += -fPIC -Os -Wall -pedantic -Wextra -Ibuild/lzfse/include -Ibuild/libzbitmap/include
+CFLAGS += -fPIC -Os -Wall -pedantic -Wextra -Ibuild/lzfse/include -Ibuild/libzbitmap/include -g -fsanitize=address
 
 # Paths for lzfse
 LZFSE_DIR = libNeoAppleArchive/compression/lzfse

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 buildDir = build
 CC = clang
-CFLAGS += -fPIC -Os -g -fsanitize=address -Wall -pedantic -Wextra -IlibNeoAppleArchive/build/lzfse/include -IlibNeoAppleArchive/build/libzbitmap/include
+CFLAGS += -fPIC -Os -g -fsanitize=address -Wall -pedantic -Wextra -Ibuild/lzfse/include -Ibuild/libzbitmap/include
 
 # Paths for lzfse
 LZFSE_DIR = libNeoAppleArchive/compression/lzfse

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 buildDir = build
 CC = clang
-CFLAGS += -fPIC -Os -Wall -pedantic -Wextra
+CFLAGS += -fPIC -Os -Wall -pedantic -Wextra -Ibuild/lzfse/include -Ibuild/libzbitmap/include
 
 # Paths for lzfse
 LZFSE_DIR = libNeoAppleArchive/compression/lzfse

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 buildDir = build
 CC = clang
-CFLAGS += -fPIC -Os
+CFLAGS += -fPIC -Os -g -fsanitize=address
 
 # Paths for lzfse
 LZFSE_DIR = libNeoAppleArchive/compression/lzfse

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 buildDir = build
 CC = clang
-CFLAGS += -fPIC -Os -g -fsanitize=address
+CFLAGS += -fPIC -Os -g -fsanitize=address -Wall -pedantic -Wextra
 
 # Paths for lzfse
 LZFSE_DIR = libNeoAppleArchive/compression/lzfse

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 buildDir = build
 CC = clang
-LDFLAGS += -IlibNeoAppleArchive/build/lzfse/include -IlibNeoAppleArchive/build/libzbitmap/include
-CFLAGS += -fPIC -Os -g -fsanitize=address -Wall -pedantic -Wextra 
+CFLAGS += -fPIC -Os -g -fsanitize=address -Wall -pedantic -Wextra -IlibNeoAppleArchive/build/lzfse/include -IlibNeoAppleArchive/build/libzbitmap/include
 
 # Paths for lzfse
 LZFSE_DIR = libNeoAppleArchive/compression/lzfse

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,24 @@
 buildDir = build
 CC = clang
-CFLAGS += -fPIC -Os -g -fsanitize=address -Wall -pedantic -Wextra
+LDFLAGS += -IlibNeoAppleArchive/build/lzfse/include -IlibNeoAppleArchive/build/libzbitmap/include
+CFLAGS += -fPIC -Os -g -fsanitize=address -Wall -pedantic -Wextra 
 
 # Paths for lzfse
 LZFSE_DIR = libNeoAppleArchive/compression/lzfse
 # The installation prefix (where the lzfse library will be built to)
 BUILD_DIR = ../../../build/lzfse
+# Paths for libzbitmap
+LIBZBITMAP_DIR = libNeoAppleArchive/compression/libzbitmap
 
 output: $(buildDir)
 	@ # Build liblzfse submodule
 	@echo "building liblzfse..."
 	$(MAKE) -C $(LZFSE_DIR) install INSTALL_PREFIX=$(BUILD_DIR)
+	@ # Build libzbitmap submodule
+	@echo "building libzbitmap..."
+	$(MAKE) -C $(LIBZBITMAP_DIR)
+	mv $(LIBZBITMAP_DIR)/libzbitmap.a build/libzbitmap/lib/
+	cp $(LIBZBITMAP_DIR)/libzbitmap.h build/libzbitmap/include/
 	@ # Build libNeoAppleArchive.a
 	@echo "building libNeoAppleArchive..."
 	@$(CC) -c libNeoAppleArchive/neo_aa_header.c -o build/obj/neo_aa_header.o $(CFLAGS)
@@ -25,3 +33,4 @@ $(buildDir):
 	mkdir build/usr/bin
 	mkdir build/obj
 	mkdir build/lzfse
+	mkdir -p build/libzbitmap/lib/ build/libzbitmap/include/

--- a/README.md
+++ b/README.md
@@ -1,35 +1,33 @@
 # libNeoAppleArchive
 Unfinished cross-compat library for parsing Apple Archive (and, by extension, YAA).
 
-### What isn't finished:
+### What isn't finished
+- Any archive with a type other than directory, regular file or symlink. Be aware this is rare however for user created `.aar`s
+- LZMA and LZ4 compressed `.aar`s; only `RAW`, `LZFSE`, and `ZLIB` are currently supported
+- Multi-Threadded support
 
-- Any archive with a type other than directory, regular file or symlink. Be aware this is rare however for user created `.aar`s.
-- LZMA and LZ4 compressed `.aar`s; only `RAW`, `LZFSE`, and `ZLIB` are currently supported.
-- Multi-Threadded support.
-
-### What is:
-
+### What is
 Functions for messing around with headers and extracting apple archives. There are functions for manually creating apple archives (or modifying existing ones), however there currently is no functions for easy archiving of a directory from a file path. Do be aware that it should be possible to do this though with the provided functions in the library. YAA is also supported, as it is just legacy Apple Archive, and all YAA files are just Apple Archives with a different magic essentially.
 
-### Roadmap:
+### Roadmap
+- [ ] Support all compression types for Apple Archive (partially complete)
+- [x] Support AEA, at least the `AEA_PROFILE__HKDF_SHA256_HMAC__NONE__ECDSA_P256` and `AEA_PROFILE__HKDF_SHA256_AESCTR_HMAC__SYMMETRIC__NONE` profiles.
+- [ ] An "IPSWDecrypt" CLI tool for Linux and Darwin platforms that can decrypt IPSW/OTA AEAs.
+- [ ] Convienience functions for archiving / extracting files and directories.
+- [ ] Making code more readable
+- [ ] GUI for Windows/macOS/Linux
 
-- Support all compression types for Apple Archive
-- Support AEA, at least the `AEA_PROFILE__HKDF_SHA256_HMAC__NONE__ECDSA_P256` and `AEA_PROFILE__HKDF_SHA256_AESCTR_HMAC__SYMMETRIC__NONE` profiles.
-- An "IPSWDecrypt" CLI tool for Linux and Darwin platforms that can decrypt IPSW/OTA AEAs.
-- Convienience functions for archiving / extracting files and directories.
-- Making code more readable
-- GUI for Windows/macOS/Linux (If this happens, this won't be for a while, just an fyi)
-  
-### Compatibility:
-
+### Compatibility
 - Most Darwin Operating Systems (macOS, iOS, watchOS, visionOS etc.) 
 - Linux
 - MinGW for Windows
 
 # NOTE
-
 This is not a reimplementation of libAppleArchive, rather its own library, created from the ground up. It is not compatible with libAppleArchive APIs, look at the header and code for clues. There is also docs available at `docs/` for types and functions.
 
-liblzfse is owned by Apple Inc. It is added as a submodule in `libNeoAppleArchive/compression/lzfse`, and the Makefile builds it into `build/lzfse`.
+# Libraries Used
+[liblzfse](https://github.com/lzfse/lzfse) is owned by Apple Inc. It is added as a submodule in `libNeoAppleArchive/compression/lzfse`, and the Makefile builds it into `build/lzfse`.
 
-ZLIB is not linked in the final executable line liblzfse but rather dynamically linked, as it is already on the OS itself.
+[libzbitmap](https://github.com/eafer/libzbitmap) is owned by Corellium LLC, but is reversed engineered from Apple Inc's implementation. It is added as a submodule in `libNeoAppleArchive/compression/libzbitmap`, and the Makefile builds it into `build/libzbitmap`.
+
+[zlib](https://zlib.net/) is not linked in the final library but is rather dynamically linked, as it is assumed to already be available on the OS itself.

--- a/libNeoAppleArchive/libNeoAppleArchive.c
+++ b/libNeoAppleArchive/libNeoAppleArchive.c
@@ -9,12 +9,15 @@
 #include "libNeoAppleArchive_internal.h"
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wstrict-prototypes"
-#include "../build/lzfse/include/lzfse.h"
+#include <lzfse.h>
 #pragma clang diagnostic pop
 #include <zlib.h>
 #include <fcntl.h>
 
 void neo_aa_extract_aar_buffer_to_path(uint8_t *appleArchive, size_t appleArchiveSize, const char *outputPath) {
+    (void)appleArchive;
+    (void)appleArchiveSize;
+    (void)outputPath;
     printf("This function does not exist. Sorry!\n");
     return;
 }

--- a/libNeoAppleArchive/libNeoAppleArchive.c
+++ b/libNeoAppleArchive/libNeoAppleArchive.c
@@ -7,7 +7,10 @@
 
 #include "libNeoAppleArchive.h"
 #include "libNeoAppleArchive_internal.h"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wstrict-prototypes"
 #include "../build/lzfse/include/lzfse.h"
+#pragma clang diagnostic pop
 #include <zlib.h>
 #include <fcntl.h>
 

--- a/libNeoAppleArchive/libNeoAppleArchive_internal.h
+++ b/libNeoAppleArchive/libNeoAppleArchive_internal.h
@@ -20,7 +20,7 @@ uint32_t internal_do_not_call_flip_edian_32(uint32_t num);
 
 #define NEO_AA_NullParamAssert(x) if (!x) {fprintf(stderr,"%s: invalid parameters.\n",__FUNCTION__);exit(1);};
 
-#define NEO_AA_LogError(msg) fprintf(stderr, "%s %s", __FUNCTION__, msg);
+#define NEO_AA_LogError(msg) fprintf(stderr, "%s: %s", __FUNCTION__, msg);
 /* Logs to stderr. printf-like. */
 #define NEO_AA_LogErrorF(fmt, ...) fprintf(stderr, "%s " fmt, __FUNCTION__, __VA_ARGS__);
 

--- a/libNeoAppleArchive/neo_aea_archive.c
+++ b/libNeoAppleArchive/neo_aea_archive.c
@@ -15,6 +15,11 @@
 #include "libNeoAppleArchive_internal.h"
 #include "neo_aea_archive.h"
 #include "../build/lzfse/include/lzfse.h"
+#include <openssl/aes.h>
+#include <openssl/kdf.h>
+#include <openssl/params.h>
+#include <openssl/param_build.h>
+#include <openssl/core_names.h>
 
 #define HMacSHA256Size 32
 
@@ -108,144 +113,649 @@ NeoAEAArchive neo_aea_archive_with_encoded_data_nocopy(uint8_t *encodedData, siz
     return aeaArchive;
 }
 
+
+__attribute__((visibility ("hidden"))) static void *hmac_derive(void *hkdf_key, void *data1, size_t data1Len, void *data2, size_t data2Len) {
+    uint8_t *hmac = malloc(HMacSHA256Size);
+    OSSL_PARAM params[4];
+
+    EVP_MAC *mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
+    if (!mac) {
+        fprintf(stderr, "Failed to fetch EVP MAC\n");
+        return NULL;
+    }
+
+    EVP_MAC_CTX *ctx = EVP_MAC_CTX_new(mac);
+    if (!ctx) {
+        fprintf(stderr, "Failed to create EVP MAC context\n");
+        return NULL;
+    }
+    
+    params[0] = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST, OSSL_DIGEST_NAME_SHA2_256, sizeof(OSSL_DIGEST_NAME_SHA2_256));
+    params[1] = OSSL_PARAM_construct_end();
+
+    /* Initialize HMAC with SHA-256 */
+    if (!EVP_MAC_init(ctx, hkdf_key, HMacSHA256Size, params)) {
+        fprintf(stderr, "Failed to initialize EVP MAC\n");
+        EVP_MAC_CTX_free(ctx);
+        EVP_MAC_free(mac);
+        return NULL;
+    }
+
+    /* Update HMAC with data */
+    if (data2 && data2Len > 0) {
+        if (!EVP_MAC_update(ctx, data2, data2Len)) {
+            fprintf(stderr, "Failed to update HMAC\n");
+            EVP_MAC_CTX_free(ctx);
+            EVP_MAC_free(mac);
+            return NULL;
+        }
+    }
+    if (data1 && data1Len > 0) {
+        if (!EVP_MAC_update(ctx, data1, data1Len)) {
+            fprintf(stderr, "Failed to update HMAC\n");
+            EVP_MAC_CTX_free(ctx);
+            EVP_MAC_free(mac);
+            return NULL;
+        }
+    }
+    if (!EVP_MAC_update(ctx, (const uint8_t *)&data2Len, 8)) {
+        fprintf(stderr, "Failed to update HMAC\n");
+        EVP_MAC_CTX_free(ctx);
+        EVP_MAC_free(mac);
+        return NULL;
+    }
+
+    /* Finalize HMAC */
+    if (!EVP_MAC_final(ctx, hmac, NULL, HMacSHA256Size)) {
+        fprintf(stderr, "Failed to finalize HMAC\n");
+        EVP_MAC_CTX_free(ctx);
+        EVP_MAC_free(mac);
+        return NULL;
+    }
+    EVP_MAC_CTX_free(ctx);
+    EVP_MAC_free(mac);
+
+    return hmac;
+}
+
+__attribute__((visibility ("hidden"))) static void *do_hkdf(void *context, size_t contextLen, void *key) {
+    void *derivedKey = malloc(512);
+    if (!derivedKey) {
+        return NULL;
+    }
+    EVP_KDF* kdf;
+    if ((kdf = EVP_KDF_fetch(NULL, "hkdf", NULL)) == NULL) {
+        return NULL;
+    }
+    EVP_KDF_CTX* ctx = EVP_KDF_CTX_new(kdf);
+    EVP_KDF_free(kdf);
+    if (ctx == NULL) {
+        return NULL;
+    }
+    OSSL_PARAM params[4] = {
+        OSSL_PARAM_construct_utf8_string("digest", "sha256", sizeof("sha256")),
+        OSSL_PARAM_construct_octet_string("key", key, 32),
+        OSSL_PARAM_construct_octet_string("info", context, contextLen),
+        OSSL_PARAM_construct_end()
+    };
+    if (EVP_KDF_CTX_set_params(ctx, params) <= 0) {
+        return NULL;
+    }
+    if (EVP_KDF_derive(ctx, derivedKey, 32, NULL) <= 0) {
+        return NULL;
+    }
+    EVP_KDF_CTX_free(ctx);
+    return derivedKey;
+}
+
+/* Helper function to perform HKDF using OpenSSL */
+__attribute__((visibility ("hidden"))) static int hkdf_extract_and_expand_helper(const uint8_t *salt, size_t salt_len,
+                            const uint8_t *key, size_t key_len,
+                            const uint8_t *info, size_t info_len,
+                            uint8_t *out, size_t out_len) {
+    EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, NULL);
+    if (!ctx) {
+        fprintf(stderr, "Failed to create HKDF context\n");
+        return 0;
+    }
+
+    if (EVP_PKEY_derive_init(ctx) <= 0) {
+        fprintf(stderr, "Failed to initialize HKDF context\n");
+        EVP_PKEY_CTX_free(ctx);
+        return 0;
+    }
+
+    if (EVP_PKEY_CTX_set_hkdf_md(ctx, EVP_sha256()) <= 0) {
+        fprintf(stderr, "Failed to set HKDF hash function\n");
+        EVP_PKEY_CTX_free(ctx);
+        return 0;
+    }
+
+    if (salt && EVP_PKEY_CTX_set1_hkdf_salt(ctx, salt, salt_len) <= 0) {
+        fprintf(stderr, "Failed to set HKDF salt\n");
+        EVP_PKEY_CTX_free(ctx);
+        return 0;
+    }
+
+    if (EVP_PKEY_CTX_set1_hkdf_key(ctx, key, key_len) <= 0) {
+        fprintf(stderr, "Failed to set HKDF key\n");
+        EVP_PKEY_CTX_free(ctx);
+        return 0;
+    }
+
+    if (EVP_PKEY_CTX_add1_hkdf_info(ctx, info, info_len) <= 0) {
+        fprintf(stderr, "Failed to set HKDF info\n");
+        EVP_PKEY_CTX_free(ctx);
+        return 0;
+    }
+
+    if (EVP_PKEY_derive(ctx, out, &out_len) <= 0) {
+        fprintf(stderr, "Failed to derive HKDF output\n");
+        EVP_PKEY_CTX_free(ctx);
+        return 0;
+    }
+
+    EVP_PKEY_CTX_free(ctx);
+    return 1;
+}
+
+int get_encoded_size(EVP_PKEY* pkey) {
+    size_t tmp;
+    if (!pkey || !EVP_PKEY_get_raw_public_key(pkey, NULL, &tmp)) {
+        return 0;
+    }
+    return tmp;
+}
+
+int serialize_pubkey(EVP_PKEY* pkey, uint8_t* buf, size_t len) {
+    if (!pkey) {
+        return 0;
+    }
+    size_t tmp = len;
+    if (!pkey || !EVP_PKEY_get_raw_public_key(pkey, buf, &tmp)) {
+        return 0;
+    }
+    return 1;
+}
+
+uint8_t* calculate_hmac(
+    uint8_t* key, size_t keySize,
+    uint8_t* data, size_t dataSize,
+    uint8_t* salt, size_t saltSize
+) {
+    size_t bufSize = saltSize + dataSize + sizeof(uint64_t);
+    uint8_t* buf = malloc(bufSize);
+    if (!buf) {
+        NEO_AA_ErrorHeapAlloc();
+        return NULL;
+    }
+    memcpy(buf, salt, saltSize);
+    memcpy(&buf[saltSize], data, dataSize);
+    memcpy(&buf[saltSize + dataSize], &saltSize, sizeof(uint64_t));
+    return hmac_derive(key, buf, bufSize, NULL, 0);
+}
+
+uint8_t* decrypt_AES_256_CTR(uint8_t* key, uint8_t* data, size_t dataSize) {
+    const EVP_CIPHER* cipher = EVP_aes_256_ctr();
+    uint8_t* decrypted = malloc(dataSize + EVP_CIPHER_block_size(cipher));
+    if (!decrypted) {
+        NEO_AA_ErrorHeapAlloc();
+        return NULL;
+    }
+    EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();
+    EVP_DecryptInit_ex(ctx, cipher, NULL, &key[32], &key[64]);
+    int outl = dataSize + EVP_CIPHER_block_size(cipher);
+    EVP_DecryptUpdate(ctx, decrypted, &outl, data, dataSize);
+    outl = dataSize + EVP_CIPHER_block_size(cipher) - outl;
+    EVP_DecryptFinal(ctx, decrypted, &outl);
+    return decrypted;
+}
+
+uint8_t* get_password_key(
+    uint8_t* password, size_t passwordLen, 
+    uint8_t* salt, size_t saltLen,
+    int hardness
+) {
+    uint8_t* out = malloc(64);
+    EVP_KDF *kdf = EVP_KDF_fetch(NULL, "SCRYPT", NULL);
+    if (!out || !kdf) {
+        NEO_AA_ErrorHeapAlloc();
+        return NULL;
+    }
+    EVP_KDF_CTX *ctx = EVP_KDF_CTX_new(kdf);
+    EVP_KDF_free(kdf);
+    uint32_t r = 8, p = 1;
+    OSSL_PARAM params[6] = {
+        OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_PASSWORD, password, passwordLen),
+        OSSL_PARAM_construct_octet_string(OSSL_KDF_PARAM_SALT, salt, saltLen),
+        OSSL_PARAM_construct_uint64(OSSL_KDF_PARAM_SCRYPT_N, (uint64_t *)&hardness),
+        OSSL_PARAM_construct_uint32(OSSL_KDF_PARAM_SCRYPT_R, &r),
+        OSSL_PARAM_construct_uint32(OSSL_KDF_PARAM_SCRYPT_P, &p),
+        OSSL_PARAM_construct_end()
+    };
+    if (EVP_KDF_derive(ctx, out, 64, params) <= 0) {
+        return NULL;
+    }
+    return out;
+}
+
+void* main_key(
+    NewNeoAEAArchive aea, 
+    EVP_PKEY* senderPub, 
+    EVP_PKEY* recPriv, 
+    EVP_PKEY* sigPub, 
+    uint8_t* symmKey, size_t symmKeySize
+) {
+    size_t len = 12 
+                + get_encoded_size(senderPub) 
+                + get_encoded_size(recPriv) 
+                + get_encoded_size(sigPub), 
+           tmp, off = 12;
+    uint8_t *context = malloc(len),
+            *mainKey = malloc(32);
+    if (!context || !mainKey) {
+        NEO_AA_ErrorHeapAlloc();
+        return NULL;
+    }
+    strcpy((char *)context, "AEA_AMK");
+    *(uint32_t *)&context[8] = aea->profileID; // is actually an uint24_t
+    context[11] = aea->scryptStrength;
+    off += serialize_pubkey(senderPub, &context[off], len - off);
+    off += serialize_pubkey(recPriv, &context[off], len - off);
+    off += serialize_pubkey(sigPub, &context[off], len - off);
+    if (!hkdf_extract_and_expand_helper(aea->keyDerivationSalt, 0x20, (uint8_t *)symmKey, symmKeySize, (uint8_t *)context, 0x4c, mainKey, 32)) {
+        return NULL;
+    }
+    return mainKey;
+}
+
+void* password_key(uint8_t* mainKey) {
+    return do_hkdf("AEA_SCRYPT", 10, mainKey);
+}
+
+void* signature_encryption_key(uint8_t* mainKey) {
+    void* derivationKey = do_hkdf("AEA_SEK", 7, mainKey);
+    return do_hkdf("AEA_SEK2", 8, derivationKey);
+}
+
+void* root_header_key(uint8_t* mainKey) {
+    return do_hkdf("AEA_RHEK", 8, mainKey);
+}
+
+void* cluster_key(uint8_t* mainKey, int idx) {
+    char context[10];
+    strcpy(context, "AEA_CK");
+    *(int *)&context[5] = idx;
+    return do_hkdf(context, 10, mainKey);
+}
+
+void* cluster_header_key(uint8_t* clusterKey) {
+    return do_hkdf("AEA_CHEK", 9, cluster_key);
+}
+
+void* segment_key(uint8_t* clusterKey, int idx) {
+    char context[10];
+    strcpy(context, "AEA_SK");
+    *(int *)&context[5] = idx;
+    return do_hkdf(context, 10, clusterKey);
+}
+
+struct aea_segment_header new_partial_segment(uint8_t* decryptedSegment, int checksumAlgorithm) {
+    size_t checksumSize = checksumSizes[checksumAlgorithm];
+    struct aea_old_segment_header* tmp = (struct aea_old_segment_header*)decryptedSegment;
+    struct aea_segment_header segment = {
+        .originalSize = tmp->originalSize,
+        .compressedSize = tmp->compressedSize
+    };
+    
+    segment.hash = malloc(checksumSize);
+    if (!segment.hash) {
+        NEO_AA_ErrorHeapAlloc();
+        return (struct aea_segment_header){};
+    }
+    memcpy(segment.hash, &decryptedSegment[8], checksumSize);
+
+    // to be initialized later
+    segment.segmentData = NULL;
+    bzero(segment.segmentHMAC, 0x20);
+
+    // all fields initialized, return the segment
+    return segment;
+}
+
+struct aea_cluster_header* new_partial_cluster(uint8_t* decryptedCluster, int numSegments, int checksumAlgorithm) {
+    struct aea_cluster_header* cluster = malloc(sizeof(struct aea_cluster_header));
+    size_t segmentHeaderSize = checksumSizes[checksumAlgorithm] + 8;
+    if (!cluster) {
+        NEO_AA_ErrorHeapAlloc();
+        return NULL;
+    }
+    cluster->segments = malloc(numSegments * segmentHeaderSize);
+    if (!cluster->segments) {
+        NEO_AA_ErrorHeapAlloc();
+        return NULL;
+    }
+    struct aea_segment_header emptySegment = (struct aea_segment_header){};
+    for (size_t i = 0; i < numSegments; i++) {
+        struct aea_segment_header segment = new_partial_segment(decryptedCluster, checksumAlgorithm);
+        if (!memcmp(&segment, &emptySegment, sizeof(struct aea_segment_header))) {
+            return NULL;
+        }
+        decryptedCluster += segmentHeaderSize;
+        cluster->segments[i] = segment;
+    }
+    memcpy(cluster->nextClusterHMAC, decryptedCluster, 0x20);
+    decryptedCluster += 0x20;
+    for (size_t i = 0; i < numSegments; i++) {
+        struct aea_segment_header* segment = &cluster->segments[i];
+        memcpy(segment->segmentHMAC, decryptedCluster, 0x20);
+        decryptedCluster += 0x20;
+    }
+    // all field initialized, return cluster
+    return cluster;
+}
+
 /*
  * neo_aea_archive_extract_data
  *
  * Extracts data from the AEA.
  * This does not validate signing.
  */
-uint8_t *neo_aea_archive_extract_data(NeoAEAArchive aea, size_t *size) {
-    /* TODO: Support more than 1 cluster, but this is only for >100mb files */
-    NEO_AA_NullParamAssert(aea);
-    if (aea->profile) {
-        NEO_AA_LogError("neo_aa_archive_plain_with_neo_aea_archive should only be called on Profile 0 unencrypted profiles\n");
-        return 0;
-    }
-    uint8_t *encodedData = (uint8_t *)aea->encodedData;
-    NEO_AA_NullParamAssert(encodedData);
-    size_t encodedDataSize = aea->encodedDataSize;
-    if (encodedDataSize <= 12) {
-        NEO_AA_LogError("size should be bigger than 12\n");
-        return 0;
-    }
-    uint32_t authDataSize = 0;
-    memcpy(&authDataSize, encodedData + 0x8, 4);
-
-    size_t archivedDirSize = 0; /* size of uncompressed LZFSE data of the Apple Archive */
-
-    /* copy struct from encoded data */
-    struct aea_profile0_post_authData postAuthData = {0};
-    /* 
-     * We don't copy the final default cluster,
-     * since we aren't 100% sure this aea will
-     * have the default 256 segments per cluster
+uint8_t *neo_aea_archive_extract_data(
+    NewNeoAEAArchive aea, 
+    size_t *size, 
+    EVP_PKEY* recPriv,
+    EVP_PKEY* signaturePub,
+    uint8_t* symmKey, size_t symmKeySize,
+    uint8_t* password, size_t passwordSize
+) {
+    /* TODO:
+       * support other compression algorithms (lz4, lzbitmap, lzvn, lzma, zlib)
+       * unit tests for all of these functions to make sure they work
+       * 
      */
-    memcpy(&postAuthData, encodedData + authDataSize + 12, sizeof(struct aea_profile0_post_authData));
+    NEO_AA_NullParamAssert(aea);
+    size_t aeaDataSize = 0; /* size of the AEA's (uncompressed) data */
+
+    if (aea->profileID == NEO_AEA_PROFILE_HKDF_SHA256_HMAC_NONE_ECDSA_P256) {
+        symmKey = aea->profileDependent;
+    } else if (HAS_SYMMETRIC_ENCRYPTION(aea->profileID)) {
+        if (!symmKey || symmKeySize != 32) {
+            return NULL;
+        }
+    }
+
+    EVP_PKEY* senderPub = NULL;
+    if (HAS_ASYMMETRIC_ENCRYPTION(aea->profileID)) {
+        senderPub = EVP_PKEY_new_raw_public_key(NID_X9_62_prime256v1, NULL, aea->profileDependent, 65);
+        if (!senderPub) {
+            return NULL;
+        }
+        EVP_PKEY_CTX* ctx = EVP_PKEY_CTX_new(recPriv, NULL);
+        symmKey = malloc(32);
+        symmKeySize = 32;
+        if ((!ctx) || (!symmKey)
+          || (EVP_PKEY_derive_init(ctx) <= 0)
+          || (EVP_PKEY_derive_set_peer(ctx, senderPub) <= 0)
+          || (EVP_PKEY_derive(ctx, symmKey, &symmKeySize) <= 0)) {
+            return NULL;
+        }
+    }
+
+    if (HAS_PASSWORD_ENCRYPTION(aea->profileID)) {
+        if (!password || !passwordSize) {
+            return NULL;
+        }
+        void* scryptCTX = malloc(10);
+        if (!scryptCTX) {
+            return NULL;
+        }
+        uint8_t* extendedSalt = password_key(aea->keyDerivationSalt);
+        memcpy(aea->keyDerivationSalt, &extendedSalt[32], 0x20);
+        symmKey = get_password_key(password, passwordSize, extendedSalt, 32, aea->scryptStrength);
+    }
+
+    if (!IS_SIGNED(aea->profileID)) {
+        signaturePub = NULL;
+    }
+
+    /* Calculate Main Key (AEA_AMK) */
+    uint8_t* mainKey = main_key(aea, senderPub, recPriv, signaturePub, symmKey, symmKeySize);
+    if (IS_ENCRYPTED(aea->profileID)) {
+        uint8_t* rootHeaderKey = root_header_key(mainKey);
+        memcpy(
+            aea->encryptedRootHeader, 
+            decrypt_AES_256_CTR(rootHeaderKey, aea->encryptedRootHeader, 0x30), 
+            0x30
+        );
+    }
+
     /* Check root header */
-    struct aea_root_header rootHeader = postAuthData.prerootHeader.rootHeader;
-    char compressionAlgo = rootHeader.compressionAlgorithm;
-    if (rootHeader.checksumAlgorithm != 2) {
+    struct aea_root_header* rootHeader = &aea->rootHeader;
+    char compressionAlgo = rootHeader->compressionAlgorithm;
+    if (rootHeader->checksumAlgorithm != 2) {
         NEO_AA_LogError("non sha256 checksum not yet supported\n");
         return 0;
     }
-    /* Calculate where segment data is */
-    struct aea_segment_header *segment0Header = (struct aea_segment_header *)(encodedData + 12 + authDataSize + sizeof(struct aea_profile0_post_authData) + HMacSHA256Size + 16);
-    int segments = 0;
-    uint32_t i;
-    struct aea_segment_header *segmentHeader = segment0Header;
-    /* Count segments and calculate archivedDirSize */
-    for (i = 0; i < rootHeader.segmentsPerCluster; i++) {
-        struct aea_segment_header _segmentHeader = *segmentHeader;
-        if (_segmentHeader.originalSize == 0 && _segmentHeader.compressedSize == 0) {
-            /* Empty segment */
-            break;
-        }
-        size_t archivedDirSizeOld = archivedDirSize;
-        archivedDirSize += _segmentHeader.originalSize;
-        if (archivedDirSize < archivedDirSizeOld) {
-            NEO_AA_LogError("archivedDirSize underflow\n");
-            return 0;
-        }
-        segments++;
-        segmentHeader += sizeof(struct aea_segment_header);
-    }
-    if (!segments) {
-        NEO_AA_LogError("aea cluster has 0 segments\n");
-        return 0;
-    }
-    int segmentOffset = (sizeof(struct aea_segment_header) * rootHeader.segmentsPerCluster);
-    if (segmentOffset < 0) {
-        NEO_AA_LogError("integer underflow in segmentOffset calculation\n");
-        return 0;
-    }
-    int clusterDataStart = 12 + authDataSize + (sizeof(struct aea_profile0_post_authData)) + HMacSHA256Size + segmentOffset;
-    if (clusterDataStart < 0) {
-        NEO_AA_LogError("integer underflow in clusterDataStart calculation\n");
-        return 0;
-    }
-    clusterDataStart += HMacSHA256Size + (rootHeader.segmentsPerCluster * HMacSHA256Size) + 16;
-    if (clusterDataStart < 0) {
-        NEO_AA_LogError("integer underflow in clusterDataStart calculation\n");
-        return 0;
-    }
-    uint8_t *encodedAppleArchive = malloc(archivedDirSize);
-    if (!encodedAppleArchive) {
+    size_t outBufferSize = 0;
+    uint8_t *aeaData = malloc(aeaDataSize);
+    if (!aeaData) {
         NEO_AA_ErrorHeapAlloc();
         return 0;
     }
-    /* Get data (uncompressed segment 0 data append segment 1 data etc...) */
-    i = 0;
-    segmentHeader = segment0Header;
-    uint8_t *segmentPtr = encodedData + clusterDataStart;
-    size_t aarSize = 0;
-    int dataOffset = 0;
-    for (i = 0; i < segments; i++) {
-        struct aea_segment_header _segmentHeader = *segmentHeader;
-        /*
-         * - = None
-         * 4 = LZ4
-         * b = LZBITMAP
-         * e = LZFSE
-         * f = LZVN
-         * x = LZMA
-         * z = ZLIB
-         */
-        size_t decompressedBytes;
-        /* 
-         * uncompressed data is either - or 0
-         * i forgot which one it is so im doing both
-         * however, even if the cluster follows a specific
-         * compression algorithm, segments over the specified
-         * segmentSize do not seem to be compressed.
-         */
-        if ((compressionAlgo == '-') || (compressionAlgo == 0) || (_segmentHeader.compressedSize > rootHeader.segmentSize && _segmentHeader.compressedSize == _segmentHeader.originalSize)) {
-            /* No compression */
-            decompressedBytes = _segmentHeader.compressedSize;
-            /* copy entire aaLZFSEPtr buffer to encodedAppleArchive */
-            memcpy(encodedAppleArchive + dataOffset, segmentPtr, _segmentHeader.compressedSize);
-        } else if (compressionAlgo == 'e') {
-            /* LZFSE compressed */
-            decompressedBytes = lzfse_decode_buffer(encodedAppleArchive + dataOffset, archivedDirSize - dataOffset, segmentPtr, _segmentHeader.compressedSize, 0);
-            if (decompressedBytes != archivedDirSize) {
-                NEO_AA_LogError("failed to decompress LZFSE data\n");
-                free(encodedAppleArchive);
+    size_t numClusters = 0,
+           clusterIndex = 0,
+           segmentHeaderSize = 8 + checksumSizes[rootHeader->checksumAlgorithm];
+
+    // Cluster Decryption Routine
+    /* 
+        During the execution of this function,
+        There is a possibility to use memory that is ~2x the file size
+        (one copy of the encrypted data, another of the decrypted)
+        Parallelization of decryption is possible given segment sizes
+            are precomputed beforehand.
+    */
+    if (IS_ENCRYPTED(aea->profileID)) {
+        uint8_t* encryptedClusters = aea->encryptedClusters;
+        size_t off = 0;
+        // no known number of clusters, so iterate until we reach the end
+        while (off < aea->clusterLen) {
+            uint8_t* clusterKey = cluster_key(mainKey, clusterIndex);
+
+            // decrypt current cluster
+            uint8_t* clusterHeaderKey = cluster_header_key(clusterKey);
+            uint8_t* decryptedCluster = decrypt_AES_256_CTR(
+                clusterHeaderKey, 
+                &encryptedClusters[off], 
+                segmentHeaderSize * rootHeader->segmentsPerCluster
+            );
+
+            // make new cluster struct (data field in segments not filled in)
+            struct aea_cluster_header* cluster = new_partial_cluster(
+                decryptedCluster, 
+                rootHeader->segmentsPerCluster, 
+                rootHeader->checksumAlgorithm
+            );
+            off += segmentHeaderSize * rootHeader->segmentsPerCluster  // segment headers
+                +  0x20 * (1 + rootHeader->segmentsPerCluster); // HMACs
+            free(decryptedCluster); // already copied into the cluster struct, no longer required
+            
+            for (size_t i = 0; i < rootHeader->segmentsPerCluster; i++) {
+                struct aea_segment_header* segment = &cluster->segments[i];
+                uint8_t* segmentKey = segment_key(clusterKey, i);
+                // EXPENSIVE -- up to 1 MB copied and decrypted per segment!
+                uint8_t* decryptedSegment = decrypt_AES_256_CTR(
+                    segmentKey, 
+                    &encryptedClusters[off], 
+                    segment->compressedSize
+                );
+                if (!decryptedSegment) {
+                    return 0;
+                }
+                // direct assignment because the whole decrypted memory belongs to this single segment
+                segment->segmentData = decryptedSegment;
+                // all fields in segment are now fully setup, we can move to next segment
+                off += segment->compressedSize; // segment data
+            }
+            // off == next cluster header offset
+        }
+        free(aea->encryptedClusters); // free encrypted clusters to not waste any more memory holding it
+        // now we should only be using memory that's the same size as the file size
+    }
+    // use aea->clusters from now on, as they are now decrypted
+
+    while (1) {
+        int numSegments = 0;
+        struct aea_segment_header *segmentHeaders = aea->clusters[clusterIndex].segments;
+        /* Count number of non-empty segments and calculate aeaDataSize */
+        for (uint32_t i = 0; i < rootHeader->segmentsPerCluster; i++) {
+            struct aea_segment_header* curSegmentHeader = &segmentHeaders[i];
+            if (curSegmentHeader->compressedSize == 0) {
+                /* Empty segment */
+                break;
+            }
+            
+            // https://stackoverflow.com/a/33948556
+            if ((aeaDataSize + curSegmentHeader->originalSize) < aeaDataSize) {
+                NEO_AA_LogError("aeaDataSize overflow\n");
                 return 0;
             }
-        } else {
-            /* Not yet supported */
-            NEO_AA_LogErrorF("compression algorithm %02x not yet supported\n", compressionAlgo);
-            free(encodedAppleArchive);
+            aeaDataSize += curSegmentHeader->originalSize;
+            numSegments++;
+        }
+        if (!numSegments) {
+            NEO_AA_LogError("AEA cluster only has empty segments\n");
             return 0;
         }
-        segmentPtr += _segmentHeader.compressedSize;
-        segmentHeader += sizeof(struct aea_segment_header);
-        dataOffset += _segmentHeader.compressedSize;
-        aarSize += decompressedBytes;
-    }
+        /* Get data (uncompressed segment 0 data append segment 1 data etc...) */
+        int dataOffset = 0;
+        for (uint32_t i = 0; i < numSegments; i++) {
+            struct aea_segment_header* curSegmentHeader = &segmentHeaders[i];
+            size_t decompressedBytes = 0;
+            /*
+             * - = None
+             * 4 = LZ4
+             * b = LZBITMAP
+             * e = LZFSE
+             * f = LZVN
+             * x = LZMA
+             * z = ZLIB
+             */
+
+            /* 
+             * Uncompressed data is -
+             * However, even if the cluster follows a specific
+             * compression algorithm, segments that have a 
+             * larger size when compressed are stored uncompressed.
+             */
+            if ((compressionAlgo == NEO_AEA_COMPRESSION_NONE) || curSegmentHeader->compressedSize == curSegmentHeader->originalSize) {
+                /* No compression */
+                decompressedBytes = curSegmentHeader->compressedSize;
+                /* copy entire aaLZFSEPtr buffer to aeaData */
+                memcpy(&aeaData[dataOffset], curSegmentHeader->segmentData, curSegmentHeader->compressedSize);
+            } else if (compressionAlgo == NEO_AEA_COMPRESSION_LZFSE) {
+                /* LZFSE compressed */
+                decompressedBytes = lzfse_decode_buffer(
+                    &aeaData[dataOffset], 
+                    curSegmentHeader->originalSize, 
+                    curSegmentHeader->segmentData, 
+                    curSegmentHeader->compressedSize, 
+                    0
+                );
+                if (decompressedBytes != curSegmentHeader->originalSize) {
+                    NEO_AA_LogError("failed to decompress LZFSE data\n");
+                    free(aeaData);
+                    return 0;
+                }
+            } else {
+                /* Not yet supported */
+                NEO_AA_LogErrorF("compression algorithm %02x not yet supported\n", compressionAlgo);
+                free(aeaData);
+                return 0;
+            }
+            dataOffset += curSegmentHeader->originalSize;
+            outBufferSize += decompressedBytes;
+        }
+
+        if (numSegments != rootHeader->segmentsPerCluster) {
+            // there were empty segments, end of cluster
+            break;
+        }
+    }   
     if (size) {
-        *size = aarSize;
+        *size = outBufferSize;
     }
-    return encodedAppleArchive;
+    return aeaData;
+}
+
+int alloc_memcpy(void** dst, void* src, size_t n) {
+    *dst = malloc(n);
+    if (!*dst) {
+        return 0;
+    }
+    memcpy(*dst, src, n);
+    return 1;
+}
+
+NewNeoAEAArchive convertFromOld(NeoAEAArchive aea) {
+    NewNeoAEAArchive newaea = calloc(1, sizeof(struct aea_archive));
+    if (!newaea) {
+        return NULL;
+    }
+    uint8_t* buf = aea->encodedData;
+    // magic, profileID, scryptStrength, authDataSize
+    memcpy(newaea, buf, 12);
+    buf += 12;
+    void *data = NULL;
+    if (!alloc_memcpy(&data, buf, newaea->authDataSize)) {
+        return NULL;
+    }
+    newaea->authData = data;
+    buf += newaea->authDataSize;
+    size_t size;
+    switch (aea->profile) {
+        case NEO_AEA_PROFILE_HKDF_SHA256_HMAC_NONE_ECDSA_P256:
+            size = 128;
+            break;
+        case NEO_AEA_PROFILE_HKDF_SHA256_AESCTR_HMAC_SYMMETRIC_ECDSA_P256:
+        case NEO_AEA_PROFILE_HKDF_SHA256_AESCTR_HMAC_ECDHE_P256_ECDSA_P256:
+            size = 160;
+            break;
+        default:
+            size = 0;
+            break;
+    }
+    if (!alloc_memcpy(&data, buf, size)) {
+        return NULL;
+    }
+    newaea->signature = data;
+    buf += size;
+    switch (aea->profile) {
+        case NEO_AEA_PROFILE_HKDF_SHA256_HMAC_NONE_ECDSA_P256:
+            size = 32;
+            break;
+        case NEO_AEA_PROFILE_HKDF_SHA256_AESCTR_HMAC_ECDHE_P256_NONE:
+        case NEO_AEA_PROFILE_HKDF_SHA256_AESCTR_HMAC_ECDHE_P256_ECDSA_P256:
+            size = 65;
+            break;
+        default:
+            size = 0;
+            break;
+    }
+    if (!alloc_memcpy(&data, buf, size)) {
+        return NULL;
+    };
+    newaea->profileDependent = data;
+    buf += size;
+    memcpy((char *)newaea + 12 + 3 * sizeof(uint8_t *), buf, 0x90);
+    buf += 0x90;
+    newaea->clusterLen = aea->encodedDataSize - (buf - aea->encodedData);
+    // EXPENSIVE: copies all clusters
+    if (!alloc_memcpy(&data, buf, newaea->clusterLen)) {
+        return NULL;
+    }
+    newaea->encryptedClusters = data;
+    return newaea;
 }
 
 /*
@@ -257,7 +767,8 @@ uint8_t *neo_aea_archive_extract_data(NeoAEAArchive aea, size_t *size) {
  */
 NeoAAArchivePlain neo_aa_archive_plain_with_neo_aea_archive(NeoAEAArchive aea) {
     size_t aarSize;
-    uint8_t *encodedAppleArchive = neo_aea_archive_extract_data(aea, &aarSize);
+    NewNeoAEAArchive newaea = convertFromOld(aea);
+    uint8_t *encodedAppleArchive = neo_aea_archive_extract_data(newaea, &aarSize, NULL, 0, NULL, 0, NULL, 0);
     if (encodedAppleArchive) {
         NEO_AA_LogError("could not extract data from aea\n");
         return 0;

--- a/libNeoAppleArchive/neo_aea_archive.c
+++ b/libNeoAppleArchive/neo_aea_archive.c
@@ -30,6 +30,7 @@
 
 #define HMacSHA256Size 32
 
+#ifdef DEBUG
 void DumpHex(const void* data, size_t size) {
 	char ascii[17];
 	size_t i, j;
@@ -58,6 +59,7 @@ void DumpHex(const void* data, size_t size) {
 		}
 	}
 }
+#endif
 
 __attribute__((visibility ("hidden"))) int alloc_memcpy(void** dst, void* src, size_t n) {
     *dst = malloc(n);
@@ -413,7 +415,7 @@ __attribute__((visibility ("hidden"))) void* main_key(
     if (senderPub) {
         int res = serialize_pubkey(senderPub, &context[off], len - off);
         if (!res) {
-            printf("serialize_pubkey failed!\n");
+            NEO_AA_LogError("serialize_pubkey failed!\n");
             return NULL;
         }
         off += res;
@@ -421,7 +423,7 @@ __attribute__((visibility ("hidden"))) void* main_key(
     if (recPriv) {
         int res = serialize_pubkey(recPriv, &context[off], len - off);
         if (!res) {
-            printf("serialize_pubkey failed!\n");
+            NEO_AA_LogError("serialize_pubkey failed!\n");
             return NULL;
         }
         off += res;
@@ -429,15 +431,11 @@ __attribute__((visibility ("hidden"))) void* main_key(
     if (sigPub) {
         int res = serialize_pubkey(sigPub, &context[off], len - off);
         if (!res) {
-            printf("serialize_pubkey failed!\n");
+            NEO_AA_LogError("serialize_pubkey failed!\n");
             return NULL;
         }
         off += res;
     }
-#ifdef DEBUG
-    printf("mainKey context:\n");
-    DumpHex(context, len);
-#endif
     if (!hkdf_extract_and_expand_helper(
             aea->keyDerivationSalt,  0x20, 
             (uint8_t *)symmKey, symmKeySize, 

--- a/libNeoAppleArchive/neo_aea_archive.c
+++ b/libNeoAppleArchive/neo_aea_archive.c
@@ -74,14 +74,14 @@ __attribute__((visibility ("hidden"))) static void *hmac_derive(void *hkdf_key, 
 
     EVP_MAC *mac = EVP_MAC_fetch(NULL, "HMAC", NULL);
     if (!mac) {
-        fprintf(stderr, "Failed to fetch EVP MAC\n");
+        NEO_AA_LogError("Failed to fetch EVP MAC\n");
         OPENSSL_ERR_PRINT();
         return NULL;
     }
 
     EVP_MAC_CTX *ctx = EVP_MAC_CTX_new(mac);
     if (!ctx) {
-        fprintf(stderr, "Failed to create EVP MAC context\n");
+        NEO_AA_LogError("Failed to create EVP MAC context\n");
         OPENSSL_ERR_PRINT();
         return NULL;
     }
@@ -91,7 +91,7 @@ __attribute__((visibility ("hidden"))) static void *hmac_derive(void *hkdf_key, 
 
     /* Initialize HMAC with SHA-256 */
     if (!EVP_MAC_init(ctx, hkdf_key, HMacSHA256Size, params)) {
-        fprintf(stderr, "Failed to initialize EVP MAC\n");
+        NEO_AA_LogError("Failed to initialize EVP MAC\n");
         OPENSSL_ERR_PRINT();
         EVP_MAC_CTX_free(ctx);
         EVP_MAC_free(mac);
@@ -101,7 +101,7 @@ __attribute__((visibility ("hidden"))) static void *hmac_derive(void *hkdf_key, 
     /* Update HMAC with data */
     if (data2 && data2Len > 0) {
         if (!EVP_MAC_update(ctx, data2, data2Len)) {
-            fprintf(stderr, "Failed to update HMAC\n");
+            NEO_AA_LogError("Failed to update HMAC\n");
             OPENSSL_ERR_PRINT();
             EVP_MAC_CTX_free(ctx);
             EVP_MAC_free(mac);
@@ -110,7 +110,7 @@ __attribute__((visibility ("hidden"))) static void *hmac_derive(void *hkdf_key, 
     }
     if (data1 && data1Len > 0) {
         if (!EVP_MAC_update(ctx, data1, data1Len)) {
-            fprintf(stderr, "Failed to update HMAC\n");
+            NEO_AA_LogError("Failed to update HMAC\n");
             OPENSSL_ERR_PRINT();
             EVP_MAC_CTX_free(ctx);
             EVP_MAC_free(mac);
@@ -118,7 +118,7 @@ __attribute__((visibility ("hidden"))) static void *hmac_derive(void *hkdf_key, 
         }
     }
     if (!EVP_MAC_update(ctx, (const uint8_t *)&data2Len, 8)) {
-        fprintf(stderr, "Failed to update HMAC\n");
+        NEO_AA_LogError("Failed to update HMAC\n");
         OPENSSL_ERR_PRINT();
         EVP_MAC_CTX_free(ctx);
         EVP_MAC_free(mac);
@@ -127,7 +127,7 @@ __attribute__((visibility ("hidden"))) static void *hmac_derive(void *hkdf_key, 
 
     /* Finalize HMAC */
     if (!EVP_MAC_final(ctx, hmac, NULL, HMacSHA256Size)) {
-        fprintf(stderr, "Failed to finalize HMAC\n");
+        NEO_AA_LogError("Failed to finalize HMAC\n");
         OPENSSL_ERR_PRINT();
         EVP_MAC_CTX_free(ctx);
         EVP_MAC_free(mac);
@@ -178,48 +178,48 @@ __attribute__((visibility ("hidden"))) static int hkdf_extract_and_expand_helper
 ) {
     EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, NULL);
     if (!ctx) {
-        fprintf(stderr, "Failed to create HKDF context\n");
+        NEO_AA_LogError("Failed to create HKDF context\n");
         OPENSSL_ERR_PRINT();
         return 0;
     }
 
     if (EVP_PKEY_derive_init(ctx) <= 0) {
-        fprintf(stderr, "Failed to initialize HKDF context\n");
+        NEO_AA_LogError("Failed to initialize HKDF context\n");
         OPENSSL_ERR_PRINT();
         EVP_PKEY_CTX_free(ctx);
         return 0;
     }
 
     if (EVP_PKEY_CTX_set_hkdf_md(ctx, EVP_sha256()) <= 0) {
-        fprintf(stderr, "Failed to set HKDF hash function\n");
+        NEO_AA_LogError("Failed to set HKDF hash function\n");
         OPENSSL_ERR_PRINT();
         EVP_PKEY_CTX_free(ctx);
         return 0;
     }
 
     if (salt && EVP_PKEY_CTX_set1_hkdf_salt(ctx, salt, salt_len) <= 0) {
-        fprintf(stderr, "Failed to set HKDF salt\n");
+        NEO_AA_LogError("Failed to set HKDF salt\n");
         OPENSSL_ERR_PRINT();
         EVP_PKEY_CTX_free(ctx);
         return 0;
     }
 
     if (EVP_PKEY_CTX_set1_hkdf_key(ctx, key, key_len) <= 0) {
-        fprintf(stderr, "Failed to set HKDF key\n");
+        NEO_AA_LogError("Failed to set HKDF key\n");
         OPENSSL_ERR_PRINT();
         EVP_PKEY_CTX_free(ctx);
         return 0;
     }
 
     if (EVP_PKEY_CTX_add1_hkdf_info(ctx, info, info_len) <= 0) {
-        fprintf(stderr, "Failed to set HKDF info\n");
+        NEO_AA_LogError("Failed to set HKDF info\n");
         OPENSSL_ERR_PRINT();
         EVP_PKEY_CTX_free(ctx);
         return 0;
     }
 
     if (EVP_PKEY_derive(ctx, out, &out_len) <= 0) {
-        fprintf(stderr, "Failed to derive HKDF output\n");
+        NEO_AA_LogError("Failed to derive HKDF output\n");
         OPENSSL_ERR_PRINT();
         EVP_PKEY_CTX_free(ctx);
         return 0;

--- a/libNeoAppleArchive/neo_aea_archive.c
+++ b/libNeoAppleArchive/neo_aea_archive.c
@@ -17,8 +17,9 @@
 // can't do anything about imported submodules
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wstrict-prototypes"
-#include "../build/lzfse/include/lzfse.h"
+#include <lzfse.h>
 #pragma clang diagnostic pop
+#include <libzbitmap.h>
 #include <zlib.h>
 #include <assert.h>
 #include <openssl/aes.h>
@@ -814,6 +815,20 @@ uint8_t *neo_aea_archive_extract_data(
                 );
                 if (decompressedBytes != curSegmentHeader->originalSize) {
                     NEO_AA_LogError("Failed to decompress LZFSE data\n");
+                    free(aeaData);
+                    return NULL;
+                }
+            } else if (compressionAlgo == NEO_AEA_COMPRESSION_LZBITMAP) {
+                size_t unused;
+                (void)unused;
+                if (zbm_decompress(
+                    &aeaData[dataOffset],
+                    curSegmentHeader->originalSize, 
+                    curSegmentHeader->segmentData,
+                    curSegmentHeader->compressedSize,
+                    &unused
+                ) < 0) {
+                    NEO_AA_LogError("Failed to decompress LZBITMAP data\n");
                     free(aeaData);
                     return NULL;
                 }

--- a/libNeoAppleArchive/neo_aea_archive.c
+++ b/libNeoAppleArchive/neo_aea_archive.c
@@ -818,9 +818,10 @@ uint8_t *neo_aea_archive_extract_data(
                     return NULL;
                 }
             } else if (compressionAlgo == NEO_AEA_COMPRESSION_ZLIB) {
+                size_t originalSize = curSegmentHeader->originalSize;
                 if (uncompress(
                     &aeaData[dataOffset],
-                    curSegmentHeader->originalSize,
+                    &originalSize,
                     curSegmentHeader->segmentData,
                     curSegmentHeader->compressedSize
                 )) {

--- a/libNeoAppleArchive/neo_aea_archive.c
+++ b/libNeoAppleArchive/neo_aea_archive.c
@@ -209,7 +209,7 @@ __attribute__((visibility ("hidden"))) static void *hmac_derive(void *hkdf_key, 
 }
 
 __attribute__((visibility ("hidden"))) static void *do_hkdf(void *context, size_t contextLen, void *key, size_t outSize) {
-    void *derivedKey = malloc(512);
+    void *derivedKey = malloc(outSize);
     if (!derivedKey) {
         return NULL;
     }

--- a/libNeoAppleArchive/neo_aea_archive.c
+++ b/libNeoAppleArchive/neo_aea_archive.c
@@ -363,7 +363,16 @@ void* main_key(
     off += serialize_pubkey(senderPub, &context[off], len - off);
     off += serialize_pubkey(recPriv, &context[off], len - off);
     off += serialize_pubkey(sigPub, &context[off], len - off);
-    if (!hkdf_extract_and_expand_helper(aea->keyDerivationSalt, 0x20, (uint8_t *)symmKey, symmKeySize, (uint8_t *)context, 0x4c, mainKey, 32)) {
+    if (!hkdf_extract_and_expand_helper(
+            aea->keyDerivationSalt, 
+            0x20, 
+            (uint8_t *)symmKey, 
+            symmKeySize, 
+            (uint8_t *)context, 
+            len, 
+            mainKey, 
+            32
+        )) {
         return NULL;
     }
     return mainKey;

--- a/libNeoAppleArchive/neo_aea_archive.c
+++ b/libNeoAppleArchive/neo_aea_archive.c
@@ -17,7 +17,7 @@
 // can't do anything about imported submodules
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wstrict-prototypes"
-#include "compression/lzfse/src/lzfse.h"
+#include <lzfse.h>
 #pragma clang diagnostic pop
 #include <libzbitmap.h>
 #include <zlib.h>

--- a/libNeoAppleArchive/neo_aea_archive.c
+++ b/libNeoAppleArchive/neo_aea_archive.c
@@ -464,7 +464,7 @@ NewNeoAEAArchive neo_aea_archive_with_encoded_data_nocopy(uint8_t *encodedData, 
     };
     aea->profileDependent = data;
     buf += size;
-    memcpy(aea + offsetof(struct aea_archive, keyDerivationSalt), buf, 0x90);
+    memcpy((char *)aea + offsetof(struct aea_archive, keyDerivationSalt), buf, 0x90);
     buf += 0x90;
     aea->clusterDataLen = encodedDataSize - (buf - encodedData);
     // EXPENSIVE: copies all clusters

--- a/libNeoAppleArchive/neo_aea_archive.c
+++ b/libNeoAppleArchive/neo_aea_archive.c
@@ -464,7 +464,7 @@ NewNeoAEAArchive neo_aea_archive_with_encoded_data_nocopy(uint8_t *encodedData, 
     };
     aea->profileDependent = data;
     buf += size;
-    memcpy((char *)aea + 12 + 3 * sizeof(uint8_t *), buf, 0x90);
+    memcpy(aea + offsetof(struct aea_archive, keyDerivationSalt), buf, 0x90);
     buf += 0x90;
     aea->clusterDataLen = encodedDataSize - (buf - encodedData);
     // EXPENSIVE: copies all clusters

--- a/libNeoAppleArchive/neo_aea_archive.c
+++ b/libNeoAppleArchive/neo_aea_archive.c
@@ -17,7 +17,7 @@
 // can't do anything about imported submodules
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wstrict-prototypes"
-#include <lzfse.h>
+#include "compression/lzfse/src/lzfse.h"
 #pragma clang diagnostic pop
 #include <libzbitmap.h>
 #include <zlib.h>

--- a/libNeoAppleArchive/neo_aea_archive.c
+++ b/libNeoAppleArchive/neo_aea_archive.c
@@ -334,7 +334,7 @@ __attribute__((visibility ("hidden"))) uint8_t* get_password_key(
 }
 
 __attribute__((visibility ("hidden"))) void* main_key(
-    NewNeoAEAArchive aea, 
+    NeoAEAArchive aea, 
     EVP_PKEY* senderPub, 
     EVP_PKEY* recPriv, 
     EVP_PKEY* sigPub, 
@@ -451,9 +451,9 @@ __attribute__((visibility ("hidden"))) struct aea_cluster_header new_partial_clu
     return cluster;
 }
 
-NewNeoAEAArchive neo_aea_archive_with_encoded_data_nocopy(uint8_t *encodedData, size_t encodedDataSize) {
+NeoAEAArchive neo_aea_archive_with_encoded_data_nocopy(uint8_t *encodedData, size_t encodedDataSize) {
     NEO_AA_NullParamAssert(encodedData);
-    NewNeoAEAArchive aea = calloc(1, sizeof(struct aea_archive));
+    NeoAEAArchive aea = calloc(1, sizeof(struct aea_archive));
     if (!aea) {
         NEO_AA_ErrorHeapAlloc();
         return 0;
@@ -561,7 +561,7 @@ NewNeoAEAArchive neo_aea_archive_with_encoded_data_nocopy(uint8_t *encodedData, 
     return aea;
 }
 
-NewNeoAEAArchive neo_aea_archive_with_encoded_data(uint8_t *encodedData, size_t encodedDataSize) {
+NeoAEAArchive neo_aea_archive_with_encoded_data(uint8_t *encodedData, size_t encodedDataSize) {
     NEO_AA_NullParamAssert(encodedData);
     uint8_t *encodedDataCopy = malloc(encodedDataSize);
     if (!encodedDataCopy) {
@@ -569,7 +569,7 @@ NewNeoAEAArchive neo_aea_archive_with_encoded_data(uint8_t *encodedData, size_t 
         return 0;
     }
     memcpy(encodedDataCopy, encodedData, encodedDataSize);
-    NewNeoAEAArchive aea = neo_aea_archive_with_encoded_data_nocopy(encodedDataCopy, encodedDataSize);
+    NeoAEAArchive aea = neo_aea_archive_with_encoded_data_nocopy(encodedDataCopy, encodedDataSize);
     if (!aea) {
         free(encodedDataCopy);
         return NULL;
@@ -577,7 +577,7 @@ NewNeoAEAArchive neo_aea_archive_with_encoded_data(uint8_t *encodedData, size_t 
     return aea;
 }
 
-NewNeoAEAArchive neo_aea_archive_with_path(const char *path) {
+NeoAEAArchive neo_aea_archive_with_path(const char *path) {
     NEO_AA_NullParamAssert(path);
     if (strlen(path) > 1024) {
         NEO_AA_LogError("path should not exceed 1024 characters\n");
@@ -601,7 +601,7 @@ NewNeoAEAArchive neo_aea_archive_with_path(const char *path) {
         return 0;
     }
     fclose(fp);
-    NewNeoAEAArchive aea = neo_aea_archive_with_encoded_data_nocopy(encodedData, encodedDataSize);
+    NeoAEAArchive aea = neo_aea_archive_with_encoded_data_nocopy(encodedData, encodedDataSize);
     if (!aea) {
         free(encodedData);
         return NULL;
@@ -617,7 +617,7 @@ NewNeoAEAArchive neo_aea_archive_with_path(const char *path) {
     Parallelization of decryption is possible given segment sizes
         are precomputed beforehand.
 */
-__attribute__((visibility ("hidden"))) int decrypt_clusters(NewNeoAEAArchive aea, uint8_t* mainKey, struct aea_root_header* rootHeader, size_t segmentHeaderSize) {
+__attribute__((visibility ("hidden"))) int decrypt_clusters(NeoAEAArchive aea, uint8_t* mainKey, struct aea_root_header* rootHeader, size_t segmentHeaderSize) {
     uint8_t* encryptedClusters = aea->encryptedClusters;
     size_t keySize = aea->profileID == NEO_AEA_PROFILE_HKDF_SHA256_HMAC_NONE_ECDSA_P256 ? 32 : 80;
     size_t off = 0, 
@@ -710,7 +710,7 @@ __attribute__((visibility ("hidden"))) int decrypt_clusters(NewNeoAEAArchive aea
  * This does not validate signing.
  */
 uint8_t *neo_aea_archive_extract_data(
-    NewNeoAEAArchive aea, 
+    NeoAEAArchive aea, 
     size_t *size, 
     EVP_PKEY* recPriv,
     EVP_PKEY* signaturePub,
@@ -718,7 +718,7 @@ uint8_t *neo_aea_archive_extract_data(
     uint8_t* password, size_t passwordSize
 ) {
     /* TODO:
-       * support other compression algorithms (lz4, lzbitmap, lzvn, lzma, zlib)
+       * support other compression algorithms (lz4, lzvn, lzma)
        * unit tests for all of these functions to make sure they work
        * more abstraction to make it easier to understand
        * etc...
@@ -930,7 +930,7 @@ end:
  * This does not validate signing. For this, use
  * neo_aa_archive_plain_with_neo_aea_archive_verify
  */
-NeoAAArchivePlain neo_aa_archive_plain_with_neo_aea_archive(NewNeoAEAArchive aea) {
+NeoAAArchivePlain neo_aa_archive_plain_with_neo_aea_archive(NeoAEAArchive aea) {
     size_t aarSize;
     uint8_t *encodedAppleArchive = neo_aea_archive_extract_data(aea, &aarSize, NULL, 0, NULL, 0, NULL, 0);
     if (encodedAppleArchive) {
@@ -942,8 +942,44 @@ NeoAAArchivePlain neo_aa_archive_plain_with_neo_aea_archive(NewNeoAEAArchive aea
 
 void neo_aea_archive_destroy(NeoAEAArchive aea) {
     NEO_AA_NullParamAssert(aea);
-    if (aea->encodedData) {
-        free(aea->encodedData);
+    if (aea->authData) {
+        free(aea->authData);
+    }
+    if (aea->signature) {
+        free(aea->signature);
+    }
+    if (aea->profileDependent) {
+        free(aea->profileDependent);
+    }
+    if (aea->isEncrypted) {
+        if (aea->encryptedClusters) {
+            free(aea->encryptedClusters);
+            aea->encryptedClusters = NULL;
+        }
+    } else if (aea->clusters) {
+        for (size_t i = 0; i numClusters; i++) {
+            struct aea_cluster_header cluster = aea->clusters[i];
+            for (uint32_t j = 0; j rootHeader.segmentsPerCluster; j++) {
+                struct aea_segment_header *segment = &cluster.segments[j];
+                if (!segment) {
+                    free(cluster.segments);
+                    goto clusters_done;
+                }
+                if (segment.compressedSize == 0) {
+                    free(cluster.segments);
+                    goto clusters_done;
+                }
+                if (segment.hash) {
+                    free(segment.hash);
+                }
+                if (segment.segmentData) {
+                    free(segment.segmentData);
+                }
+            }
+            free(cluster.segments);
+        }
+clusters_done:
+        free(aea->clusters);
     }
     free(aea);
 }

--- a/libNeoAppleArchive/neo_aea_archive.h
+++ b/libNeoAppleArchive/neo_aea_archive.h
@@ -21,6 +21,9 @@
 
 #include <stdio.h>
 #include <openssl/evp.h>
+#include <openssl/err.h>
+
+#define OPENSSL_ERR_PRINT() fprintf(stderr, "OpenSSL Error at %s in %s:%d: \n", __func__, __FILE__, __LINE__); ERR_print_errors_fp(stderr)
 
 /* Different types of AEA, should be same as AEAProfiles definition */
 typedef enum {

--- a/libNeoAppleArchive/neo_aea_archive.h
+++ b/libNeoAppleArchive/neo_aea_archive.h
@@ -19,6 +19,7 @@
 #define neo_aea_archive_h
 
 #include <stdio.h>
+#include <openssl/evp.h>
 
 /* Different types of AEA, should be same as AEAProfiles definition */
 typedef enum {
@@ -29,6 +30,107 @@ typedef enum {
     NEO_AEA_PROFILE_HKDF_SHA256_AESCTR_HMAC_ECDHE_P256_ECDSA_P256 = 4,
     NEO_AEA_PROFILE_HKDF_SHA256_AESCTR_HMAC_SCRYPT_NONE = 5,
 } NeoAEAProfile;
+
+typedef enum {
+    NEO_AEA_COMPRESSION_NONE = '-',
+    NEO_AEA_COMPRESSION_LZ4 = '4',
+    NEO_AEA_COMPRESSION_LZBITMAP = 'b',
+    NEO_AEA_COMPRESSION_LZFSE = 'e',
+    NEO_AEA_COMPRESSION_LZVN = 'f',
+    NEO_AEA_COMPRESSION_LZMA = 'x',
+    NEO_AEA_COMPRESSION_ZLIB = 'z',
+} NeoAEACompressionTypes;
+
+static int checksumSizes[3] = {
+    0, // None
+    8, // Murmur64
+    0x20 // SHA-256
+};
+
+#define IS_ENCRYPTED(x) (x != NEO_AEA_PROFILE_HKDF_SHA256_HMAC_NONE_ECDSA_P256)
+#define IS_SIGNED(x) ((x == NEO_AEA_PROFILE_HKDF_SHA256_HMAC_NONE_ECDSA_P256) \
+                   || (x == NEO_AEA_PROFILE_HKDF_SHA256_AESCTR_HMAC_SYMMETRIC_ECDSA_P256) \
+                   || (x == NEO_AEA_PROFILE_HKDF_SHA256_AESCTR_HMAC_ECDHE_P256_ECDSA_P256))
+#define HAS_SYMMETRIC_ENCRYPTION(x) ((x == NEO_AEA_PROFILE_HKDF_SHA256_AESCTR_HMAC_SYMMETRIC_NONE) \
+                                  || (x == NEO_AEA_PROFILE_HKDF_SHA256_AESCTR_HMAC_SYMMETRIC_ECDSA_P256))
+#define HAS_ASYMMETRIC_ENCRYPTION(x) ((x == NEO_AEA_PROFILE_HKDF_SHA256_AESCTR_HMAC_ECDHE_P256_NONE) \
+                                   || (x == NEO_AEA_PROFILE_HKDF_SHA256_AESCTR_HMAC_ECDHE_P256_ECDSA_P256))
+#define HAS_PASSWORD_ENCRYPTION(x) (x == NEO_AEA_PROFILE_HKDF_SHA256_AESCTR_HMAC_SCRYPT_NONE)
+
+struct __attribute__((packed)) aea_root_header {
+    uint64_t originalFileSize;
+    uint64_t encryptedFileSize;
+    uint32_t segmentSize;
+    uint32_t segmentsPerCluster;
+    uint8_t compressionAlgorithm;
+    uint8_t checksumAlgorithm;
+    uint8_t reserved[22];
+};
+
+struct aea_cluster_header {
+    // size: rootHeader->segmentsPerCluster
+    struct aea_segment_header* segments;
+    uint8_t nextClusterHMAC[0x20];
+};
+
+struct aea_segment_header {
+    uint32_t originalSize;
+    uint32_t compressedSize;
+    /* size: based on rootHeader.checksumAlgorithm
+       0 for checksumAlgorithm 0
+       8 for checksumAlgorithm 1 (Murmur64 Hash)
+       32 for checksumAlgorithm 2 (SHA-256)
+     */
+    uint8_t* hash;
+    uint8_t segmentHMAC[0x20];
+    // size: compressedSize
+    uint8_t* segmentData;
+};
+
+struct __attribute__((packed)) aea_archive {
+    uint32_t magic;
+    uint32_t profileID: 24; // actually an uint24_t
+    uint8_t scryptStrength;
+    uint32_t authDataSize;
+    // size: authDataSize
+    uint8_t* authData;
+    /* size: 
+     * 128 for profile 0 (ECDSA-P256)
+     * 160 for profile 2 or 4
+     * 0 otherwise
+     */
+    uint8_t* signature;
+    /* size:
+     * 32 for profile 0 (Key Derivation Seed)
+     * 65 for profile 3 or 4 (Sender Public Key)
+     * 0 otherwise
+     */
+    uint8_t* profileDependent;
+    uint8_t keyDerivationSalt[0x20];
+    uint8_t rootHeaderHMAC[0x20];
+    // size: 0x30
+    union {
+        struct aea_root_header rootHeader;
+        uint8_t encryptedRootHeader[0x30];
+    };
+    uint8_t cluster0HeaderHMAC[0x20];
+    size_t clusterLen; // internal field, not in the file itself
+    union {
+        // size: clusterLen
+        uint8_t* encryptedClusters;
+        // size: TBD at runtime
+        struct aea_cluster_header* clusters;
+    };
+};
+
+typedef struct aea_archive *NewNeoAEAArchive;
+
+
+
+
+
+
+// ======== starting from here: old struct definitions kept for compatibility reasons ========
 
 /* Do not manually access items of neo_aea_archive_impl !!! They are subject to change!!! */
 struct neo_aea_archive_impl {
@@ -49,22 +151,15 @@ struct neo_aea_archive_impl {
 
 typedef struct neo_aea_archive_impl *NeoAEAArchive;
 
-
-
-struct aea_root_header {
-    uint64_t originalFileSize;
-    uint64_t encryptedFileSize;
-    uint32_t segmentSize;
-    uint32_t segmentsPerCluster;
-    char compressionAlgorithm;
-    uint8_t checksumAlgorithm;
-    uint8_t reserved;
-};
-
-struct aea_segment_header {
+struct aea_old_segment_header {
     uint32_t originalSize;
     uint32_t compressedSize;
-    uint8_t sha256[32];
+    /* size: based on rootHeader.checksumAlgorithm
+       0 for checksumAlgorithm 0
+       8 for checksumAlgorithm 1 (Murmur64 Hash)
+       32 for checksumAlgorithm 2 (SHA-256)
+     */
+    uint8_t hash[0x20];
 };
 
 struct aea_header {
@@ -114,7 +209,14 @@ struct aea_profile0_post_authData {
 NeoAEAArchive neo_aea_archive_with_path(const char *path);
 NeoAEAArchive neo_aea_archive_with_encoded_data(uint8_t *encodedData, size_t encodedDataSize);
 NeoAEAArchive neo_aea_archive_with_encoded_data_nocopy(uint8_t *encodedData, size_t encodedDataSize);
-uint8_t *neo_aea_archive_extract_data(NeoAEAArchive aea, size_t *size);
+uint8_t *neo_aea_archive_extract_data(
+    NewNeoAEAArchive aea, 
+    size_t *size, 
+    EVP_PKEY* recPriv,
+    EVP_PKEY* signaturePub,
+    uint8_t* symmKey, size_t symmKeySize,
+    uint8_t* password, size_t passwordSize
+);
 NeoAAArchivePlain neo_aa_archive_plain_with_neo_aea_archive(NeoAEAArchive aea);
 NeoAEAProfile neo_aea_archive_profile(NeoAEAArchive aea);
 void neo_aea_archive_destroy(NeoAEAArchive aea);

--- a/libNeoAppleArchive/neo_aea_archive.h
+++ b/libNeoAppleArchive/neo_aea_archive.h
@@ -114,12 +114,18 @@ struct __attribute__((packed)) aea_archive {
         uint8_t encryptedRootHeader[0x30];
     };
     uint8_t cluster0HeaderHMAC[0x20];
-    size_t clusterLen; // internal field, not in the file itself
     union {
-        // size: clusterLen
-        uint8_t* encryptedClusters;
+        struct {
+            size_t clusterDataLen; // data length of clusters for encrypted
+            // size: clusterDataLen
+            uint8_t* encryptedClusters;
+        };
         // size: TBD at runtime
-        struct aea_cluster_header* clusters;
+        struct {
+            size_t numClusters, // number of clusters that follow for decrypted
+                   innerDataLen; // length of data that is actually contained in the clusters -> segments
+            struct aea_cluster_header* clusters;
+        };
     };
 };
 

--- a/libNeoAppleArchive/neo_aea_archive.h
+++ b/libNeoAppleArchive/neo_aea_archive.h
@@ -1,3 +1,4 @@
+
 /*
  *  neo_aea_archive.h
  *  libNeoAppleArchive
@@ -222,9 +223,9 @@ struct aea_profile0_post_authData {
     struct aea_preroot_header prerootHeader;
 };
 
-NeoAEAArchive neo_aea_archive_with_path(const char *path);
-NeoAEAArchive neo_aea_archive_with_encoded_data(uint8_t *encodedData, size_t encodedDataSize);
-NeoAEAArchive neo_aea_archive_with_encoded_data_nocopy(uint8_t *encodedData, size_t encodedDataSize);
+NewNeoAEAArchive neo_aea_archive_with_path(const char *path);
+NewNeoAEAArchive neo_aea_archive_with_encoded_data(uint8_t *encodedData, size_t encodedDataSize);
+NewNeoAEAArchive neo_aea_archive_with_encoded_data_nocopy(uint8_t *encodedData, size_t encodedDataSize);
 uint8_t *neo_aea_archive_extract_data(
     NewNeoAEAArchive aea, 
     size_t *size, 
@@ -233,7 +234,7 @@ uint8_t *neo_aea_archive_extract_data(
     uint8_t* symmKey, size_t symmKeySize,
     uint8_t* password, size_t passwordSize
 );
-NeoAAArchivePlain neo_aa_archive_plain_with_neo_aea_archive(NeoAEAArchive aea);
+NeoAAArchivePlain neo_aa_archive_plain_with_neo_aea_archive(NewNeoAEAArchive aea);
 NeoAEAProfile neo_aea_archive_profile(NeoAEAArchive aea);
 void neo_aea_archive_destroy(NeoAEAArchive aea);
 

--- a/libNeoAppleArchive/neo_aea_archive.h
+++ b/libNeoAppleArchive/neo_aea_archive.h
@@ -101,6 +101,10 @@ struct aea_segment_header {
     uint8_t* segmentData;
 };
 
+
+
+/* Do not manually access items of aea_archive !!! They are subject to change!!! */
+
 struct __attribute__((packed)) aea_archive {
     uint32_t magic;
     uint32_t profileID: 24; // actually an uint24_t
@@ -143,7 +147,7 @@ struct __attribute__((packed)) aea_archive {
     };
 };
 
-typedef struct aea_archive *NewNeoAEAArchive;
+typedef struct aea_archive *NeoAEAArchive;
 
 
 
@@ -151,25 +155,6 @@ typedef struct aea_archive *NewNeoAEAArchive;
 
 
 // ======== starting from here: old struct definitions kept for compatibility reasons ========
-
-/* Do not manually access items of neo_aea_archive_impl !!! They are subject to change!!! */
-struct neo_aea_archive_impl {
-    size_t encodedDataSize;
-    uint8_t *encodedData;
-    /*
-     * In the future for public use,
-     * We should probably implement field keys into
-     * NeoAEAArchive, but for now I'm only
-     * using this for AEAProfile 0 extraction
-     * so I'll only implement the public key
-     * for now...
-     */
-    uint8_t *publicSigningKey; /* buffer containing ECDSA-P256 public signing key */
-    size_t publicSigningKeySize; /* should always be 65 */
-    NeoAEAProfile profile;
-};
-
-typedef struct neo_aea_archive_impl *NeoAEAArchive;
 
 struct aea_old_segment_header {
     uint32_t originalSize;
@@ -226,18 +211,18 @@ struct aea_profile0_post_authData {
     struct aea_preroot_header prerootHeader;
 };
 
-NewNeoAEAArchive neo_aea_archive_with_path(const char *path);
-NewNeoAEAArchive neo_aea_archive_with_encoded_data(uint8_t *encodedData, size_t encodedDataSize);
-NewNeoAEAArchive neo_aea_archive_with_encoded_data_nocopy(uint8_t *encodedData, size_t encodedDataSize);
+NeoAEAArchive neo_aea_archive_with_path(const char *path);
+NeoAEAArchive neo_aea_archive_with_encoded_data(uint8_t *encodedData, size_t encodedDataSize);
+NeoAEAArchive neo_aea_archive_with_encoded_data_nocopy(uint8_t *encodedData, size_t encodedDataSize);
 uint8_t *neo_aea_archive_extract_data(
-    NewNeoAEAArchive aea, 
+    NeoAEAArchive aea, 
     size_t *size, 
     EVP_PKEY* recPriv,
     EVP_PKEY* signaturePub,
     uint8_t* symmKey, size_t symmKeySize,
     uint8_t* password, size_t passwordSize
 );
-NeoAAArchivePlain neo_aa_archive_plain_with_neo_aea_archive(NewNeoAEAArchive aea);
+NeoAAArchivePlain neo_aa_archive_plain_with_neo_aea_archive(NeoAEAArchive aea);
 NeoAEAProfile neo_aea_archive_profile(NeoAEAArchive aea);
 void neo_aea_archive_destroy(NeoAEAArchive aea);
 

--- a/libNeoAppleArchive/neo_aea_archive.h
+++ b/libNeoAppleArchive/neo_aea_archive.h
@@ -41,6 +41,16 @@ typedef enum {
     NEO_AEA_COMPRESSION_ZLIB = 'z',
 } NeoAEACompressionTypes;
 
+#define MAIN_KEY_INFO                            "AEA_AMK"
+#define ROOT_HEADER_ENCRYPTED_KEY_INFO           "AEA_RHEK"
+#define CLUSTER_KEY_INFO                         "AEA_CK"
+#define CLUSTER_KEY_MATERIAL_INFO                "AEA_CHEK"
+#define SCRYPT_KEY_INFO                          "AEA_SCRYPT"
+#define SEGMENT_KEY_INFO                         "AEA_SK"
+#define SIGNATURE_ENCRYPTION_DERIVATION_KEY_INFO "AEA_SEK"
+#define SIGNATURE_ENCRYPTION_KEY_INFO            "AEA_SEK2"
+#define PADDING_KEY_INFO                         "AEA_PAK"
+
 static int checksumSizes[3] = {
     0, // None
     8, // Murmur64

--- a/libNeoAppleArchive/neo_aea_archive.h
+++ b/libNeoAppleArchive/neo_aea_archive.h
@@ -22,6 +22,7 @@
 #include <stdio.h>
 #include <openssl/evp.h>
 #include <openssl/err.h>
+#include <stdbool.h>
 
 #define OPENSSL_ERR_PRINT() fprintf(stderr, "OpenSSL Error at %s in %s:%d: \n", __func__, __FILE__, __LINE__); ERR_print_errors_fp(stderr)
 
@@ -132,6 +133,7 @@ struct __attribute__((packed)) aea_archive {
         uint8_t encryptedRootHeader[0x30];
     };
     uint8_t cluster0HeaderHMAC[0x20];
+    bool isEncrypted;
     union {
         struct {
             size_t clusterDataLen; // data length of clusters for encrypted


### PR DESCRIPTION
## Current Issue 
Only Profile 0 out of the 6 different AEA types are currently supported in the library, and only supports having a single cluster. Thus, this pull request aims to support all profile types through implementation of decryption, and support for clusters. However, these changes do break the function signature of `neo_aea_archive_extract_data`, thus making it a breaking change.

## Testing
All profiles with LZFSE compression and multiple clusters/segments have currently been tested to be working, however this pull request will be submitted as an draft until testing of all compression types are completed.

## Developed OS
This code was created on macOS.
